### PR TITLE
54 rename generic

### DIFF
--- a/globsim/JRA.py
+++ b/globsim/JRA.py
@@ -16,7 +16,7 @@ import netCDF4       as nc
 import numpy         as np
 
 from datetime            import datetime, timedelta
-from generic     import StationListRead, str_encode, series_interpolate, variables_skip, GenericDownload, GenericScale, GenericInterpolate
+from common_utils     import StationListRead, str_encode, series_interpolate, variables_skip, GenericDownload, GenericScale, GenericInterpolate
 from nc_elements import netcdf_base, new_interpolated_netcdf, new_scaled_netcdf
 from meteorology import LW_downward, pressure_from_elevation
 from os                  import path, listdir, remove, makedirs
@@ -871,7 +871,7 @@ class JRAinterpolate(GenericInterpolate):
         ncfile_out: Full path to the output netCDF file to write.     
         
         points: A dictionary of locations. See method StationListRead in
-                generic.py for more details.
+                common_utils.py for more details.
     
         variables:  List of variable(s) to interpolate such as 
                     [air_temperature, easteard_wind, northward_wind, 

--- a/globsim/__init__.py
+++ b/globsim/__init__.py
@@ -2,6 +2,6 @@
 # from ecmwfapi.api import ECMWFDataServer
 # from era_interim import *
 # from globsim import *
-# from generic import *
+# from common_utils import *
 
 name = "globsim"

--- a/globsim/common_utils.py
+++ b/globsim/common_utils.py
@@ -151,7 +151,7 @@ class GenericInterpolate:
                     multiple files (def ERA2station())
 
             points: A dictionary of locations. See method StationListRead in
-                    generic.py for more details.
+                    common_utils.py for more details.
 
             tmask_chunk:
 

--- a/globsim/data_check.py
+++ b/globsim/data_check.py
@@ -16,7 +16,7 @@ from __future__        import print_function
 from datetime          import datetime, timedelta, date
 from os                import path
 #from netCDF4           import Dataset, MFDataset
-from generic           import StationListRead
+from common_utils           import StationListRead
 
 import tomlkit
 import numpy as np

--- a/globsim/era5.py
+++ b/globsim/era5.py
@@ -55,7 +55,7 @@ from fnmatch import filter
 import urllib3
 urllib3.disable_warnings()
 
-from generic import StationListRead, series_interpolate, variables_skip, str_encode, GenericDownload, GenericScale, GenericInterpolate
+from common_utils import StationListRead, series_interpolate, variables_skip, str_encode, GenericDownload, GenericScale, GenericInterpolate
 from nc_elements import netcdf_base, new_interpolated_netcdf, new_scaled_netcdf
 from meteorology import spec_hum_kgkg, pressure_from_elevation
 
@@ -682,7 +682,7 @@ class ERA5interpolate(GenericInterpolate):
         ncfile_out: Full path to the output netCDF file to write.     
         
         points: A dictionary of locations. See method StationListRead in
-                generic.py for more details.
+                common_utils.py for more details.
     
         variables:  List of variable(s) to interpolate such as 
                     ['r', 't', 'u','v', 't2m', 'u10', 'v10', 'ssrd', 'strd', 'tp'].

--- a/globsim/era_interim.py
+++ b/globsim/era_interim.py
@@ -48,7 +48,7 @@ from datetime            import datetime, timedelta
 from ecmwfapi.api        import ECMWFDataServer
 from math                import exp, floor, atan2, pi
 from os                  import path, listdir, remove, makedirs
-from generic     import StationListRead, series_interpolate, variables_skip, str_encode, cummulative2total, GenericDownload, GenericScale, GenericInterpolate
+from common_utils     import StationListRead, series_interpolate, variables_skip, str_encode, cummulative2total, GenericDownload, GenericScale, GenericInterpolate
 from nc_elements import netcdf_base, new_interpolated_netcdf, new_scaled_netcdf
 from meteorology import spec_hum_kgkg, LW_downward, pressure_from_elevation
 from scipy.interpolate   import interp1d
@@ -719,7 +719,7 @@ class ERAIinterpolate(GenericInterpolate):
         ncfile_out: Full path to the output netCDF file to write.     
         
         points: A dictionary of locations. See method StationListRead in
-                generic.py for more details.
+                common_utils.py for more details.
     
         variables:  List of variable(s) to interpolate such as 
                     ['r', 't', 'u','v', 't2m', 'u10', 'v10', 'ssrd', 'strd', 'tp'].

--- a/globsim/exporttools.py
+++ b/globsim/exporttools.py
@@ -7,7 +7,7 @@ import pandas as pd
 import netCDF4 as nc
 import numpy as np
 
-from .generic import variables_skip
+from .common_utils import variables_skip
 
 
 def globsimScaled2Pandas(ncdf_in, station_nr):

--- a/globsim/merra_2.py
+++ b/globsim/merra_2.py
@@ -112,7 +112,7 @@ from os                import path, listdir, makedirs, remove
 from netCDF4           import Dataset, MFDataset
 from dateutil.rrule    import rrule, DAILY
 from math              import exp, floor, atan2, pi
-from generic import StationListRead, str_encode, series_interpolate, variables_skip, get_begin_date, GenericDownload, GenericScale, GenericInterpolate, get_begin_date
+from common_utils import StationListRead, str_encode, series_interpolate, variables_skip, get_begin_date, GenericDownload, GenericScale, GenericInterpolate, get_begin_date
 from meteorology import spec_hum_kgkg, LW_downward, pressure_from_elevation
 from nc_elements import netcdf_base, new_interpolated_netcdf, new_scaled_netcdf
 from scipy.interpolate import interp1d, griddata, RegularGridInterpolator, NearestNDInterpolator, LinearNDInterpolator
@@ -769,7 +769,7 @@ class MERRAgeneric():
         the variable list passed from the gridded original netCDF.
         
         ncfile_out: full name of the file to be created
-        stations:   station list read with generic.StationListRead() 
+        stations:   station list read with common_utils.StationListRead() 
         variables:  variables read from netCDF handle
         lev:        list of pressure levels, empty is [] (default)
         '''
@@ -1911,7 +1911,7 @@ class MERRAinterpolate(GenericInterpolate):
         ncfile_out: Full path to the output netCDF file to write.     
         
         points: A dictionary of locations. See method StationListRead in
-                generic.py for more details.
+                common_utils.py for more details.
     
         variables:  List of variable(s) to interpolate such as 
                     ['T','RH','U','V',' T2M', 'U2M', 'V2M', 'U10M', 'V10M', 

--- a/globsim/nc_elements.py
+++ b/globsim/nc_elements.py
@@ -2,7 +2,7 @@
 functions for creating netcdf files
 """
 import netCDF4 as nc
-from generic import variables_skip, str_encode
+from common_utils import variables_skip, str_encode
 from os import path
 import numpy as np
 def nc_new_file(ncfile_out, featureType="timeSeries", fmt='NETCDF4_CLASSIC'):
@@ -133,7 +133,7 @@ def new_interpolated_netcdf(ncfile_out, stations, nc_in, time_units):
     the variable list passed from the gridded original netCDF.
 
     ncfile_out: full name of the file to be created
-    stations:   station list read with generic.StationListRead()
+    stations:   station list read with common_utils.StationListRead()
     variables:  variables read from netCDF handle
     lev:        list of pressure levels, empty is [] (default)
     """


### PR DESCRIPTION
As recommended by @hgmacc , the module name `generic` has been changed to `common_utils`. In the future, the classes `GenericDownload` `GenericScale` and `GenericInterpolate` could be moved to their own modules, leaving the new `common_utils` module for functions that are shared between different data providers. 

closes #54