### PR TITLE
Give more control over output files during scaling and interpolation

### DIFF
--- a/docs/source/Operation.rst
+++ b/docs/source/Operation.rst
@@ -15,18 +15,18 @@ Downloading
    **Keyword**                    **Description** 
 -------------------------         ------------- 
 
-**project_directory**             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled.
-**credentials_directory**         The location of the credential files (e.g. `.merrarc` and `.jrarc`).  Does not apply to credential file .ecmwfapi which defaults to your home directory. It is recommended to set this parameter to your home directory
-**chunk_size**                    How many days to include in each download file.  Larger chunk size values mean that a smaller number of files will be downloaded, each with a larger size
-**bbN**                           Coordinates for northern boundary of bounding box describing the area for which data will be downloaded.  Coordinates must be in decimal degrees.
-**bbS**                           Coordinates for southern boundary of bounding box describing the area for which data will be downloaded. Coordinates must be in decimal degrees.
-**bbW**                           Coordinates for western boundary of bounding box describing the area for which data will be downloaded.  Coordinates must be in decimal degrees with negative values for locations west of 0.
-**bbE**                           Coordinates for eastern boundary of bounding box describing the area for which data will be downloaded. Coordinates must be in decimal degrees with negative values for locations west of 0.    
-**ele_min**                       Minimum elevation that will be downloaded. Recommended to leave at 0.
-**ele_max**                       Maximum elevation that will be downloaded. Should be at least 2500.
-**beg**                           First date for which data is downloaded YYYY/MM/DD
-**end**                           Last date for which data is downloaded YYYY/MM/DD
-**variables**                     Which variables should be downloaded from the server. The variables names come from the `CF Standard Names table <http://cfconventions.org/Data/cf-standard-names/59/build/cf-standard-name-table.html>`_.  It is recommended that the variables parameter be left to include all relevant variables: air_temperature, relative_humidity, precipitation_amount, downwelling_longwave_flux_in_air, downwelling_longwave_flux_in_air_assuming_clear_sky, downwelling_shortwave_flux_in_air, downwelling_shortwave_flux_in_air_assuming_clear_sky,  wind_from_direction, wind_speed
+``project_directory``             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled.
+``credentials_directory``         The location of the credential files (e.g. `.merrarc` and `.jrarc`).  Does not apply to credential file .ecmwfapi which defaults to your home directory. It is recommended to set this parameter to your home directory
+``chunk_size``                    How many days to include in each download file.  Larger chunk size values mean that a smaller number of files will be downloaded, each with a larger size
+``bbN``                           Coordinates for northern boundary of bounding box describing the area for which data will be downloaded.  Coordinates must be in decimal degrees.
+``bbS``                           Coordinates for southern boundary of bounding box describing the area for which data will be downloaded. Coordinates must be in decimal degrees.
+``bbW``                           Coordinates for western boundary of bounding box describing the area for which data will be downloaded.  Coordinates must be in decimal degrees with negative values for locations west of 0.
+``bbE``                           Coordinates for eastern boundary of bounding box describing the area for which data will be downloaded. Coordinates must be in decimal degrees with negative values for locations west of 0.    
+``ele_min``                       Minimum elevation that will be downloaded. Recommended to leave at 0.
+``ele_max``                       Maximum elevation that will be downloaded. Should be at least 2500.
+``beg``                           First date for which data is downloaded YYYY/MM/DD
+``end``                           Last date for which data is downloaded YYYY/MM/DD
+``variables``                     Which variables should be downloaded from the server. The variables names come from the `CF Standard Names table <http://cfconventions.org/Data/cf-standard-names/59/build/cf-standard-name-table.html>`_.  It is recommended that the variables parameter be left to include all relevant variables: air_temperature, relative_humidity, precipitation_amount, downwelling_longwave_flux_in_air, downwelling_longwave_flux_in_air_assuming_clear_sky, downwelling_shortwave_flux_in_air, downwelling_shortwave_flux_in_air_assuming_clear_sky,  wind_from_direction, wind_speed
 =========================         =============
 
 .. note:: To check download progress, you can use your credentials to log onto the website for `JRA <https://rda.ucar.edu/#ckrqst>`_ and `ERA5 (CDS API) <https://cds.climate.copernicus.eu/cdsapp#!/yourrequests>`_
@@ -37,12 +37,13 @@ Interpolating
 =========================         ===============
    **Keyword**                    **Description** 
 -------------------------         ---------------
-**project_directory**             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled. 
-**station_list**                  The filename of a csv containing site names and coordinates. If just the filename is specified without a path, globsim will look in the ``par`` folder within the project directory. If a full filepath is used, globsim will use that file instead. Typically the same ``station_list`` file will also be used in the scaling step.
-**chunk_size**                    How many time-steps to interpolate at once. This helps memory management. Keep small for large area files and/or computers with little memory. Make larger to get performance improvements on computers with lots of memory.
-**beg**                           Beginning of date range for which data will be interpolated in YYYY/MM/DD format.  Note that this date range must include dates that are represented in the downloaded data.
-**end**                           End of date range for which data will be interpolated in YYYY/MM/DD format.  Note that this date range must include dates that are represented in the downloaded data.
-**variables**                     Which variables should be downloaded from the server. The variables names come from the `CF Standard Names table <http://cfconventions.org/Data/cf-standard-names/59/build/cf-standard-name-table.html>`_.  It is recommended that the variables parameter be left to include all relevant variables
+``project_directory``             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled. 
+``output_directory``              The directory to which interpolated files will be saved. If not provided, globsim will write to the ``project_directory`` by default. 
+``station_list``                  The filename of a csv containing site names and coordinates. If just the filename is specified without a path, globsim will look in the ``par`` folder within the project directory. If a full filepath is used, globsim will use that file instead. Typically the same ``station_list`` file will also be used in the scaling step.
+``chunk_size``                    How many time-steps to interpolate at once. This helps memory management. Keep small for large area files and/or computers with little memory. Make larger to get performance improvements on computers with lots of memory.
+``beg``                           Beginning of date range for which data will be interpolated in ``YYYY/MM/DD`` format.  Note that this date range must include dates that are represented in the downloaded data.
+``end``                           End of date range for which data will be interpolated in ``YYYY/MM/DD`` format.  Note that this date range must include dates that are represented in the downloaded data.
+``variables``                     Which variables should be downloaded from the server. The variables names come from the `CF Standard Names table <http://cfconventions.org/Data/cf-standard-names/59/build/cf-standard-name-table.html>`_.  It is recommended that the variables parameter be left to include all relevant variables
 =========================         ===============
 
 
@@ -52,12 +53,12 @@ Rescaling
 =========================         ===============
    **Keyword**                    **Description** 
 -------------------------         ---------------
-**project_directory**             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled.
-**station_list**                  The filename (without path) of csv containing site information such as *sitelist.csv* (note that this must match the interpolation parameter file)
-**output_file**                   Path to output netCDF to be created. 
-**overwrite**                     Either *true* or *false*. Whether or not to overwrite the `output_file` if it exists.
-**time_step**                     The desired output time step in hours
-**kernels**                       Which processing kernels should be used. Missing or misspelled kernels will be ignored by globsim.
+``project_directory``             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled.
+``station_list``                  The filename (without path) of csv containing site information such as *sitelist.csv* (note that this must match the interpolation parameter file)
+``output_file``                   Path to output netCDF to be created. 
+``overwrite``                     Either ``true`` or ``false``. Whether or not to overwrite the ``output_file`` if it exists.
+``time_step``                     The desired output time step in hours
+``kernels``                       Which processing kernels should be used. Missing or misspelled kernels will be ignored by globsim.
 =========================         ===============
 
 Example Parameter File
@@ -140,7 +141,7 @@ This is an example of a Globsim station list file. The resulting netCDF file wil
      
 Project directory
 ^^^^^^^^^^^^^^^^^     
-The **project directory** is the location to which data is downloaded and where processed data is found. The project directory is subdivided by re-analysis type and by the type of derived product::
+The ``project directory`` is the location to which data is downloaded and where processed data is found. The project directory is subdivided by re-analysis type and by the type of derived product::
 
      project_a/              (project directory)
      project_a/par/          (parameter files for data download and interpolation)

--- a/docs/source/Operation.rst
+++ b/docs/source/Operation.rst
@@ -38,7 +38,7 @@ Interpolating
    **Keyword**                    **Description** 
 -------------------------         ---------------
 ``project_directory``             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled. 
-``output_directory``              The directory to which interpolated files will be saved. If not provided, globsim will write to the ``project_directory`` by default. 
+``output_directory``              The directory to which interpolated files will be saved. If not provided, or if the directory does not exist, globsim will write to the ``project_directory`` by default. 
 ``station_list``                  The filename of a csv containing site names and coordinates. If just the filename is specified without a path, globsim will look in the ``par`` folder within the project directory. If a full filepath is used, globsim will use that file instead. Typically the same ``station_list`` file will also be used in the scaling step.
 ``chunk_size``                    How many time-steps to interpolate at once. This helps memory management. Keep small for large area files and/or computers with little memory. Make larger to get performance improvements on computers with lots of memory.
 ``beg``                           Beginning of date range for which data will be interpolated in ``YYYY/MM/DD`` format.  Note that this date range must include dates that are represented in the downloaded data.
@@ -53,7 +53,8 @@ Rescaling
 =========================         ===============
    **Keyword**                    **Description** 
 -------------------------         ---------------
-``project_directory``             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled.
+``project_directory``             This is the full path to the project directory that contains the interpolated files. By default, it contains a subdirectory called /par where site list csv files are kept.
+``output_directory``              The directory to which scaled files will be saved. If not provided, or if the directory does not exist, globsim will write to the ``project_directory`` by default. 
 ``station_list``                  The filename (without path) of csv containing site information such as *sitelist.csv* (note that this must match the interpolation parameter file)
 ``output_file``                   Path to output netCDF to be created. 
 ``overwrite``                     Either ``true`` or ``false``. Whether or not to overwrite the ``output_file`` if it exists.

--- a/docs/source/Operation.rst
+++ b/docs/source/Operation.rst
@@ -38,7 +38,7 @@ Interpolating
    **Keyword**                    **Description** 
 -------------------------         ---------------
 **project_directory**             This is the full path to the project directory which stores the downloaded files and the control files. It should include a subdirectory called /par which contains parameter files (control files) as well as a csv describing the sites to which data are scaled. 
-**station_list**                  The filename (without path) of csv containing site information such as *sitelist.csv* (note that this must match the scaling parameter file)
+**station_list**                  The filename of a csv containing site names and coordinates. If just the filename is specified without a path, globsim will look in the ``par`` folder within the project directory. If a full filepath is used, globsim will use that file instead. Typically the same ``station_list`` file will also be used in the scaling step.
 **chunk_size**                    How many time-steps to interpolate at once. This helps memory management. Keep small for large area files and/or computers with little memory. Make larger to get performance improvements on computers with lots of memory.
 **beg**                           Beginning of date range for which data will be interpolated in YYYY/MM/DD format.  Note that this date range must include dates that are represented in the downloaded data.
 **end**                           End of date range for which data will be interpolated in YYYY/MM/DD format.  Note that this date range must include dates that are represented in the downloaded data.

--- a/examples/Example1/par/example_config.toml
+++ b/examples/Example1/par/example_config.toml
@@ -54,6 +54,9 @@ variables = ["air_temperature", "relative_humidity", "wind_speed", "wind_from_di
 # Path to the parent directory of /par - It should match the download and interpolate files
 project_directory = "/opt/globsim/examples/Example1"
 
+# (optional) output directory. If an output directory is provided and exists, scaled files will be saved in that location instead of the project_directory.
+output_directory = "/opt/globsim/examples/Example1"
+
 # Filename (without path) of csv containing site information (must match interpolation control file)
 station_list = "siteslist.csv"
 

--- a/examples/Example1/par/example_config.toml
+++ b/examples/Example1/par/example_config.toml
@@ -31,7 +31,10 @@ variables = ["air_temperature", "relative_humidity", "wind_speed", "wind_from_di
 # Path to the parent directory of /par - It should match the download and scale files
 project_directory = "/opt/globsim/examples/Example1"
 
-# Filename (without path) of csv containing site information (must match scaling control file)
+# (optional) output directory. If an output directory is provided and exists, interpolated files will be saved in that location instead of the project_directory.
+output_directory = "/opt/globsim/examples/Example1"
+
+# Filename of csv containing site information. If just a file name is provided without a path, globsim will look in the project_directory/par directory
 station_list = "siteslist.csv"
 
 # How many time steps to interpolate at once? This helps memory management.

--- a/globsim/download/ERA5download.py
+++ b/globsim/download/ERA5download.py
@@ -438,11 +438,11 @@ class ERA5download(GenericDownload, ERA5generic):
         self.era5type = era5type
 
         if self.era5type == 'reanalysis':
-            self._set_data_directory("era5")
+            self.__set_input_directory("era5")
             self.topo_file = 'era5_rea_to.nc'
             
         elif self.era5type == 'ensemble_members':
-            self._set_data_directory("era5ens")
+            self.__set_input_directory("era5ens")
             self.topo_file = 'era5_ens_to.nc'
             
         # time bounds

--- a/globsim/download/ERAIdownload.py
+++ b/globsim/download/ERAIdownload.py
@@ -529,7 +529,7 @@ class ERAIdownload(GenericDownload):
     def __init__(self, pfile):
         super().__init__(pfile)
         par = self.par
-        self._set_data_directory("erai")
+        self.__set_input_directory("erai")
 
         # time bounds
         self.date  = {'beg': datetime.strptime(par['beg'], '%Y/%m/%d'),

--- a/globsim/download/GenericDownload.py
+++ b/globsim/download/GenericDownload.py
@@ -39,7 +39,7 @@ class GenericDownload(object):
         self.elevation = {'min': par['ele_min'],
                           'max': par['ele_max']}
 
-    def _set_data_directory(self, name):
+    def __set_input_directory(self, name):
         self.directory = path.join(self.par['project_directory'], name)
         if not path.isdir(self.directory):
             makedirs(self.directory)

--- a/globsim/download/JRAdownload.py
+++ b/globsim/download/JRAdownload.py
@@ -538,7 +538,7 @@ class JRAdownload(GenericDownload):
     def __init__(self, pfile):
         super().__init__(pfile)
         par = self.par
-        self._set_data_directory("jra55")
+        self.__set_input_directory("jra55")
 
         self.dsID = 'ds628.0'
 

--- a/globsim/download/MERRAdownload.py
+++ b/globsim/download/MERRAdownload.py
@@ -424,7 +424,7 @@ class MERRAdownload(GenericDownload):
         super().__init__(pfile)
         par = self.par
 
-        self._set_data_directory("merra2")
+        self.__set_input_directory("merra2")
 
         # chunk size for downloading and storing data [days]
         self.chunk_size = par['chunk_size']

--- a/globsim/interpolate/ERA5interpolate.py
+++ b/globsim/interpolate/ERA5interpolate.py
@@ -26,10 +26,10 @@ class ERA5interpolate(GenericInterpolate):
         self.era5type = era5type
 
         if self.era5type == 'reanalysis':
-            self._set_data_directory("era5")
+            self.__set_input_directory("era5")
             self.ens = False
         elif self.era5type == 'ensemble_members':
-            self._set_data_directory("era5ens")
+            self.__set_input_directory("era5ens")
             self.ens = True
 
         # convert longitude to ERA notation if using negative numbers
@@ -45,9 +45,9 @@ class ERA5interpolate(GenericInterpolate):
         nome = 'era5_{}_{}_*.nc'
 
         if levStr == 'to':
-            infile = path.join(self.dir_raw, 'era5_{}_to.nc'.format(typeStr))
+            infile = path.join(self.input_dir, 'era5_{}_to.nc'.format(typeStr))
         else:
-            infile = path.join(self.dir_raw, nome.format(typeStr, levStr))
+            infile = path.join(self.input_dir, nome.format(typeStr, levStr))
 
         return infile
 
@@ -57,7 +57,7 @@ class ERA5interpolate(GenericInterpolate):
             nome = 'era5_ens_{}_'.format(levStr) + self.list_name + '.nc'
         else:
             nome = 'era5_rea_{}_'.format(levStr) + self.list_name + '.nc'
-        outfile = path.join(self.dir_inp, nome)
+        outfile = path.join(self.output_dir, nome)
 
         return outfile
 
@@ -364,5 +364,5 @@ class ERA5interpolate(GenericInterpolate):
             outf = 'era5_ens_pl_'
         else:
             outf = 'era5_rea_pl_'
-        outf = path.join(self.dir_inp, outf + self.list_name + '_surface.nc')
+        outf = path.join(self.output_dir, outf + self.list_name + '_surface.nc')
         self.levels2elevation(self.getOutFile('pl'), outf)

--- a/globsim/interpolate/ERAIinterpolate.py
+++ b/globsim/interpolate/ERAIinterpolate.py
@@ -31,7 +31,7 @@ class ERAIinterpolate(GenericInterpolate):
     def __init__(self, ifile):
         super().__init__(ifile)
         par = self.par
-        self.dir_raw = path.join(par['project_directory'], 'erai')
+        self.input_dir = path.join(par['project_directory'], 'erai')
 
         #convert longitude to ERA notation if using negative numbers
         self.stations['longitude_dd'] = self.stations['longitude_dd'] % 360
@@ -275,8 +275,8 @@ class ERAIinterpolate(GenericInterpolate):
         # pressure level variable keys.
         dummy_date  = {'beg' : datetime(1979, 1, 1, 12, 0),
                        'end' : datetime(1979, 1, 1, 12, 0)}
-        self.ERA2station(path.join(self.dir_raw,'erai_to.nc'),
-                         path.join(self.dir_inp,'erai_to_' +
+        self.ERA2station(path.join(self.input_dir,'erai_to.nc'),
+                         path.join(self.output_dir,'erai_to_' +
                                    self.list_name + '.nc'), self.stations,
                                    ['z', 'lsm'], date = dummy_date)
 
@@ -290,8 +290,8 @@ class ERAIinterpolate(GenericInterpolate):
                                         # [kg m-2] Total column W vapor
                 'wind_speed' : ['u10', 'v10']}   # [m s-1] 10m values
         varlist = self.TranslateCF2short(dpar)
-        self.ERA2station(path.join(self.dir_raw,'erai_sa_*.nc'),
-                         path.join(self.dir_inp,'erai_sa_' +
+        self.ERA2station(path.join(self.input_dir,'erai_sa_*.nc'),
+                         path.join(self.output_dir,'erai_sa_' +
                                    self.list_name + '.nc'), self.stations,
                                    varlist, date = self.date)
 
@@ -305,8 +305,8 @@ class ERAIinterpolate(GenericInterpolate):
                 'downwelling_shortwave_flux_in_air' : ['ssrd'],
                 'downwelling_longwave_flux_in_air'  : ['strd']}
         varlist = self.TranslateCF2short(dpar)
-        self.ERA2station(path.join(self.dir_raw,'erai_sf_*.nc'),
-                         path.join(self.dir_inp,'erai_sf_' +
+        self.ERA2station(path.join(self.input_dir,'erai_sf_*.nc'),
+                         path.join(self.output_dir,'erai_sf_' +
                                    self.list_name + '.nc'), self.stations,
                                    varlist, date = self.date)
 
@@ -318,14 +318,14 @@ class ERAIinterpolate(GenericInterpolate):
                 'relative_humidity' : ['r'],           # [%]
                 'wind_speed'        : ['u', 'v']}      # [m s-1]
         varlist = self.TranslateCF2short(dpar).append('z')
-        self.ERA2station(path.join(self.dir_raw,'erai_pl_*.nc'),
-                         path.join(self.dir_inp,'erai_pl_' +
+        self.ERA2station(path.join(self.input_dir,'erai_pl_*.nc'),
+                         path.join(self.output_dir,'erai_pl_' +
                                    self.list_name + '.nc'), self.stations,
                                    varlist, date = self.date)
 
         # 1D Interpolation for Pressure Level Data
-        self.levels2elevation(path.join(self.dir_inp,'erai_pl_' +
+        self.levels2elevation(path.join(self.output_dir,'erai_pl_' +
                                         self.list_name + '.nc'),
-                              path.join(self.dir_inp,'erai_pl_' +
+                              path.join(self.output_dir,'erai_pl_' +
                                         self.list_name + '_surface.nc'))
 

--- a/globsim/interpolate/GenericInterpolate.py
+++ b/globsim/interpolate/GenericInterpolate.py
@@ -6,6 +6,7 @@ import tomlkit
 
 from datetime import datetime, timedelta
 from os import path, makedirs, listdir
+from pathlib import Path
 from fnmatch import filter as fnmatch_filter
 
 from globsim.common_utils import StationListRead, str_encode
@@ -39,10 +40,10 @@ class GenericInterpolate:
         self.dir_inp = self.make_output_directory(par)
         self.variables = par['variables']
         self.list_name = par['station_list'].split(path.extsep)[0]
-        self.stations_csv = path.join(par['project_directory'],
-                                      'par', par['station_list'])
+        
 
         # read station points
+        self.stations_csv = self.find_stations_csv(par)
         self.stations = StationListRead(self.stations_csv)
 
         # time bounds, add one day to par['end'] to include entire last day
@@ -52,6 +53,16 @@ class GenericInterpolate:
         # chunk size: how many time steps to interpolate at the same time?
         # A small chunk size keeps memory usage down but is slow.
         self.cs = int(par['chunk_size'])
+
+    def find_stations_csv(self, par):
+        if Path(par['station_list']).is_file():
+            return Path(par['station_list'])
+        
+        elif Path(par['project_directory'], 'par', par['station_list']).is_file():
+            return Path(par['project_directory'], 'par', par['station_list'])
+        
+        else:
+            raise FileNotFoundError(f"Siteslist file {par['station_list']} not found.")
 
     def _set_data_directory(self, name):
         self.dir_raw = path.join(self.par['project_directory'], name)

--- a/globsim/interpolate/GenericInterpolate.py
+++ b/globsim/interpolate/GenericInterpolate.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import numpy as np
 import re
 import tomlkit
+import warnings
 
 from datetime import datetime, timedelta
 from os import path, makedirs, listdir
@@ -41,7 +42,6 @@ class GenericInterpolate:
         self.variables = par['variables']
         self.list_name = par['station_list'].split(path.extsep)[0]
         
-
         # read station points
         self.stations_csv = self.find_stations_csv(par)
         self.stations = StationListRead(self.stations_csv)
@@ -201,14 +201,23 @@ class GenericInterpolate:
 
     def make_output_directory(self, par):
         """make directory to hold outputs"""
+        output_root = None
         
-        if par.get('output_directory') and Path(par.get('output_directory')).is_dir():
-            output_root = Path(par.get('output_directory'))
+        if par.get('output_directory'):
+            try:
+                test_path = Path(par.get('output_directory'))
+            except TypeError:
+                warnings.warn("You provided an output_directory for interpolation that was not understood. Saving files to project directory.")
+            
+            if test_path.is_dir():
+                output_root = Path(par.get('output_directory'))
+            else:
+                warnings.warn("You provided an output_directory for interpolation that does not exist. Saving files to project directory.")
         
-        else:
+        if not output_root:
             output_root = path.join(par['project_directory'], 'interpolated')
 
-        if not (path.isdir(output_root)):
+        if not Path(output_root).is_dir():
             makedirs(output_root)
 
         return output_root

--- a/globsim/interpolate/JRAinterpolate.py
+++ b/globsim/interpolate/JRAinterpolate.py
@@ -35,7 +35,7 @@ class JRAinterpolate(GenericInterpolate):
         super().__init__(ifile)
         par = self.par
 
-        self.dir_raw = path.join(par['project_directory'],'jra55')
+        self.input_dir = path.join(par['project_directory'],'jra55')
 
         # Override inherited chunk size
         self.cs *= 200
@@ -283,8 +283,8 @@ class JRAinterpolate(GenericInterpolate):
                 'relative_humidity' : ['relative_humidity'],  # [%]
                 'wind_speed' : ['eastward_wind', 'northward_wind']}  # [m s-1] 2m & 10m values
         varlist = self.TranslateCF2short(dpar)
-        self.JRA2station(path.join(self.dir_raw,'jra55_sa_*.nc'),
-                            path.join(self.dir_inp,'jra_sa_' +
+        self.JRA2station(path.join(self.input_dir,'jra55_sa_*.nc'),
+                            path.join(self.output_dir,'jra_sa_' +
                                       self.list_name + '.nc'), self.stations,
                                       varlist, date=self.date)
 
@@ -297,8 +297,8 @@ class JRAinterpolate(GenericInterpolate):
                 'downwelling_longwave_flux_in_air_assuming_clear_sky': ['downwelling_longwave_flux_in_air_assuming_clear_sky'],
                 'precipitation_amount' : ['total_precipitation']}  # [W/m2] long-wave downward assuming clear sky
         varlist = self.TranslateCF2short(dpar)
-        self.JRA2station(path.join(self.dir_raw,'jra55_sf_*.nc'),
-                         path.join(self.dir_inp,'jra_sf_' +
+        self.JRA2station(path.join(self.input_dir,'jra55_sf_*.nc'),
+                         path.join(self.output_dir,'jra_sf_' +
                                    self.list_name + '.nc'), self.stations,
                                    varlist, date=self.date)
 
@@ -309,13 +309,13 @@ class JRAinterpolate(GenericInterpolate):
                 'relative_humidity' : ['relative_humidity'],  # [%]
                 'wind_speed'        : ['eastward_wind', 'northward_wind']}  # [m s-1]
         varlist = self.TranslateCF2short(dpar).append('geopotential_height')
-        self.JRA2station(path.join(self.dir_raw,'jra55_pl_*.nc'),
-                         path.join(self.dir_inp,'jra_pl_' +
+        self.JRA2station(path.join(self.input_dir,'jra55_pl_*.nc'),
+                         path.join(self.output_dir,'jra_pl_' +
                                    self.list_name + '.nc'), self.stations,
                                    varlist, date=self.date)
 
         # 1D Interpolation for Pressure Level Data
-        self.levels2elevation(path.join(self.dir_inp,'jra_pl_' +
+        self.levels2elevation(path.join(self.output_dir,'jra_pl_' +
                                         self.list_name + '.nc'),
-                              path.join(self.dir_inp,'jra_pl_' +
+                              path.join(self.output_dir,'jra_pl_' +
                                         self.list_name + '_surface.nc'))

--- a/globsim/interpolate/MERRAinterpolate.py
+++ b/globsim/interpolate/MERRAinterpolate.py
@@ -27,7 +27,7 @@ class MERRAinterpolate(GenericInterpolate):
         super().__init__(ifile)
         par = self.par
 
-        self.dir_raw = path.join(par['project_directory'],'merra2')
+        self.input_dir = path.join(par['project_directory'],'merra2')
 
     def netCDF_empty(self, ncfile_out, stations, nc_in):
         # TODO: change date type from f4 to f8 for lat and lon
@@ -325,8 +325,8 @@ class MERRAinterpolate(GenericInterpolate):
         dummy_date = {'beg' : datetime(1992, 1, 2, 3, 0),
                       'end' : datetime(1992, 1, 2, 4, 0)}
 
-        if not path.isdir(self.dir_inp):
-            makedirs(self.dir_inp)
+        if not path.isdir(self.output_dir):
+            makedirs(self.output_dir)
 
         # === 2D Interpolation for Surface Analysis Data ===
         # dictionary to translate CF Standard Names into MERRA2
@@ -335,8 +335,8 @@ class MERRAinterpolate(GenericInterpolate):
                 'wind_speed' : ['U2M', 'V2M', 'U10M','V10M'],   # [m s-1] 2m & 10m values
                 'relative_humidity' : ['QV2M']}  # 2m value
         varlist = self.TranslateCF2short(dpar)
-        self.MERRA2station(path.join(self.dir_raw,'merra_sa_*.nc'),
-                           path.join(self.dir_inp,'merra2_sa_' + self.list_name + '.nc'),
+        self.MERRA2station(path.join(self.input_dir,'merra_sa_*.nc'),
+                           path.join(self.output_dir,'merra2_sa_' + self.list_name + '.nc'),
                            self.stations, varlist, date=self.date)
 
         # 2D Interpolation for Single-level Radiation Diagnostics Data 'SWGDN',
@@ -350,8 +350,8 @@ class MERRAinterpolate(GenericInterpolate):
                 'downwelling_shortwave_flux_in_air_assuming_clear_sky': ['SWGDNCLR'],  # [W/m2] short-wave downward assuming clear sky
                 'downwelling_longwave_flux_in_air_assuming_clear_sky': ['LWGDNCLR']}  # [W/m2] long-wave downward assuming clear sky
         varlist = self.TranslateCF2short(dpar)
-        self.MERRA2station(path.join(self.dir_raw,'merra_sf_*.nc'),
-                           path.join(self.dir_inp,'merra2_sf_' + self.list_name + '.nc'),
+        self.MERRA2station(path.join(self.input_dir,'merra_sf_*.nc'),
+                           path.join(self.output_dir,'merra2_sf_' + self.list_name + '.nc'),
                            self.stations, varlist, date=self.date)
 
         # NEED ADD 'H' in it!
@@ -362,10 +362,10 @@ class MERRAinterpolate(GenericInterpolate):
                 'wind_speed'        : ['U', 'V'],      # [m s-1]
                 'relative_humidity' : ['RH']}          # [1]
         varlist = self.TranslateCF2short(dpar).append('H')
-        self.MERRA2station(path.join(self.dir_raw,'merra_pl_*.nc'),
-                           path.join(self.dir_inp,'merra2_pl_' + self.list_name + '.nc'),
+        self.MERRA2station(path.join(self.input_dir,'merra_pl_*.nc'),
+                           path.join(self.output_dir,'merra2_pl_' + self.list_name + '.nc'),
                            self.stations, varlist, date=self.date)
 
         # 1D Interpolation for Pressure Level Analyzed Meteorological Data
-        self.levels2elevation(path.join(self.dir_inp,'merra2_pl_' + self.list_name + '.nc'),
-                              path.join(self.dir_inp,'merra2_pl_' + self.list_name + '_surface.nc'))
+        self.levels2elevation(path.join(self.output_dir,'merra2_pl_' + self.list_name + '.nc'),
+                              path.join(self.output_dir,'merra2_pl_' + self.list_name + '_surface.nc'))

--- a/globsim/scale/GenericScale.py
+++ b/globsim/scale/GenericScale.py
@@ -22,7 +22,7 @@ class GenericScale:
             config = tomlkit.parse(FILE.read())
             self.par = par = config['scale']
         self.intpdir = path.join(par['project_directory'], 'interpolated')
-        self.scdir = self.makeOutDir(par)
+        self.output_dir = self.make_output_directory(par)
         self.list_name = par['station_list'].split(path.extsep)[0]
 
         # get the station file
@@ -36,23 +36,26 @@ class GenericScale:
         if not isinstance(self.kernels, list):
             self.kernels = [self.kernels]
 
-    def getOutNCF(self, par, src, scaleDir='scale'):
+    def getOutNCF(self, par, data_source_name):
         """make out file name"""
 
         timestep = str(par['time_step']) + 'h'
-        src = '_'.join(['scaled', src, timestep])
+        src = '_'.join(['scaled', data_source_name, timestep])
 
         src = src + '.nc'
-        fname = path.join(self.scdir, src)
+        fname = path.join(self.output_dir, src)
 
         return fname
 
-    def makeOutDir(self, par):
+    def make_output_directory(self, par):
         """make directory to hold outputs"""
+        if par.get('output_directory') and Path(par.get('output_directory')).is_dir():
+            output_root = Path(par.get('output_directory'))
+        
+        else:
+            output_root = path.join(par['project_directory'], 'scaled')
 
-        dirSC = path.join(par['project_directory'], 'scaled')
+        if not (path.isdir(output_root)):
+            makedirs(output_root)
 
-        if not (path.isdir(dirSC)):
-            makedirs(dirSC)
-
-        return dirSC
+        return output_root

--- a/globsim/scale/GenericScale.py
+++ b/globsim/scale/GenericScale.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
 
 import tomlkit
+import warnings
 
 from os import path, makedirs
+from pathlib import Path
 
 from globsim.common_utils import StationListRead
 
@@ -49,13 +51,23 @@ class GenericScale:
 
     def make_output_directory(self, par):
         """make directory to hold outputs"""
-        if par.get('output_directory') and Path(par.get('output_directory')).is_dir():
-            output_root = Path(par.get('output_directory'))
+        output_dir = None
         
-        else:
-            output_root = path.join(par['project_directory'], 'scaled')
+        if par.get('output_directory'):
+            try:
+                test_path = Path(par.get('output_directory'))
+            except TypeError:
+                warnings.warn("You provided an output_directory for scaled files that does not exist. Saving files to project directory")
+            
+            if test_path.is_dir():
+                output_dir = Path(par.get('output_directory'))
+            else:
+                warnings.warn("You provided an output_directory for scaled files that was not understood. Saving files to project directory.")
+                
+        if not output_dir:
+            output_dir = path.join(par['project_directory'], 'scaled')
 
-        if not (path.isdir(output_root)):
-            makedirs(output_root)
+        if not Path(output_dir).is_dir():
+            makedirs(output_dir)
 
-        return output_root
+        return output_dir


### PR DESCRIPTION
closes #18 

**solution**:

create a new toml file parameter (`output_directory`) for interpolate and scale steps. If `output_directory` is missing, the `project_directory` is used for output (backwards-compatible). If `output_directory` is provided and it exists, globsim will write the corresponding files there instead.

