### PR TITLE
fix bug with precip scaling in JRA55

### DIFF
--- a/globsim/scale/JRAscale.py
+++ b/globsim/scale/JRAscale.py
@@ -37,7 +37,7 @@ class JRAscale(GenericScale):
     """
     NAME = "JRA-55"
     REANALYSIS = "jra55"
-    SCALING = {"sf": {"Total precipitation": (24 * 3600, 0)},
+    SCALING = {"sf": {"Total precipitation": (1 / (24 * 3600), 0)},
                "sa": {},
                "pl": {}}
 
@@ -121,6 +121,10 @@ class JRAscale(GenericScale):
         return jra55name
     
     def get_values(self, file:str, jra55name:str, _slice=None, attr=None):
+        """ Get JRA-55 or 3Q values in common units
+
+        Handles name differences and  scale-offset conversions 
+        between JRA55 and JRA3Q """
         f = self.get_file(file)
         n = self.get_name(file, jra55name)
         
@@ -424,7 +428,7 @@ class JRAscale(GenericScale):
     def PREC_mm_sur(self):
         """
         Precipitation derived from surface data, exclusively.
-        Convert unit: mm/day to mm/s (kg m-2 s-1)
+        Convert unit: to mm/s (kg m-2 s-1)
         """
 
         # add variable to ncdf file
@@ -437,7 +441,7 @@ class JRAscale(GenericScale):
 
         # interpolate station by station
         time_in = self.get_values("sf","time")
-        values  = self.get_values("sf","Total precipitation") / (24 * 3600)  # [mm/s]
+        values  = self.get_values("sf","Total precipitation")  # We expect this in [mm/s]. 'get_values' handles conversion
         for n, s in enumerate(self.rg.variables['station'][:].tolist()):
             f = interp1d(time_in, values[:, n], kind='linear')
             self.rg.variables[vn][:, n] = f(self.times_out_nc) * self.scf


### PR DESCRIPTION
previously, code was modified to harmonize JRA55 and JRA3Q values before running them through the scaling kernel.  But the JRA3Q adjustedment was being applied to jRA55 so the precip values were too big.

Changed it so the inverse scale (1/(24*3600) is applied to jRA55 and the scalign kernel expects mm/s